### PR TITLE
Updated to be Django 1.10 compliant

### DIFF
--- a/redactor/urls.py
+++ b/redactor/urls.py
@@ -1,5 +1,5 @@
 try:
-    from django.conf.urls import url, patterns
+    from django.conf.urls import url
 except ImportError:
     from django.conf.urls.defaults import url, patterns
 
@@ -7,8 +7,7 @@ from redactor.views import DefaultRedactorUploadView
 from redactor.forms import FileForm
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         '^upload/image/(?P<upload_to>.*)',
         DefaultRedactorUploadView.as_view(),
@@ -18,3 +17,4 @@ urlpatterns = patterns(
         DefaultRedactorUploadView.as_view(),
         {'form_class': FileForm},
         name='redactor_upload_file'))
+    ]


### PR DESCRIPTION
patterns() is deprecated as of 1.10. Simple fix to urls.py to make them 1.10 compliant.