### PR TITLE
Updates for recent Django

### DIFF
--- a/redactor/widgets.py
+++ b/redactor/widgets.py
@@ -44,7 +44,7 @@ class RedactorEditor(widgets.Textarea):
         options.update(self.custom_options)
         return json.dumps(options)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, renderer=None, attrs=None):
         html = super(RedactorEditor, self).render(name, value, attrs)
         final_attrs = self.build_attrs(attrs)
         id_ = final_attrs.get('id')

--- a/redactor/widgets.py
+++ b/redactor/widgets.py
@@ -1,7 +1,10 @@
 import json
 from django.forms import widgets
 from django.utils.safestring import mark_safe
-from django.core.urlresolvers import reverse
+try:
+    from django.core.urlresolvers import reverse
+except ModuleNotFoundError:
+    from django.urls import reverse
 from django.conf import settings
 
 


### PR DESCRIPTION
I'd like to fix ModuleNotFoundError in widgets.py

[More info](https://stackoverflow.com/questions/43139081/importerror-no-module-named-django-core-urlresolvers) regarding this deprecation

I also changed widgets, since widget argument `renderer` is required in Django 2.1 and it was missing.